### PR TITLE
Bump version to 8.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,16 @@ From the *same OS version* as your target, do:
     $ cd ..
     $ ls -1
     README.md
-    sentry_8.9.0-1.dsc
-    sentry_8.9.0-1.tar.gz
-    sentry_8.9.0-1_amd64.changes
-    sentry_8.9.0-1_amd64.deb
+    sentry_8.10.0-1.dsc
+    sentry_8.10.0-1.tar.gz
+    sentry_8.10.0-1_amd64.changes
+    sentry_8.10.0-1_amd64.deb
 
 ## some more details
 
 ### sentry
 
-The target sentry version is 8.9.0. postinst calls `sentry init
+The target sentry version is 8.10.0. postinst calls `sentry init
 /etc/sentry/sentry.conf.py` if this file doesn't exist already, so as
 to provide a sample configuration file.
 

--- a/pkg/debian/changelog
+++ b/pkg/debian/changelog
@@ -1,3 +1,9 @@
+sentry (8.10.0-1) dhatim; urgency=medium
+
+  *  bump version
+
+ --   Dhatim <contact@dhatim.net>  Sun, 06 Nov 2016 15:47:00 +0200
+
 sentry (8.9.0-2) dhatim; urgency=medium
 
   *  integrate sentry-slack

--- a/pkg/debian/rules
+++ b/pkg/debian/rules
@@ -1,4 +1,6 @@
 #!/usr/bin/make -f
+override_dh_virtualenv:
+    dh_virtualenv --extra-pip-arg='--no-binary=:all:'
 
 %:
 	dh $@ --with python-virtualenv

--- a/pkg/debian/rules
+++ b/pkg/debian/rules
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 override_dh_virtualenv:
-    dh_virtualenv --extra-pip-arg='--no-binary=:all:'
+	dh_virtualenv --extra-pip-arg='--no-binary=:all:'
 
 %:
 	dh $@ --with python-virtualenv

--- a/pkg/debian/rules
+++ b/pkg/debian/rules
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
-override_dh_virtualenv:
-	dh_virtualenv --extra-pip-arg='--no-binary=:all:'
+override_dh_strip:
+	dh_strip --exclude=cffi --exclude=lxml
 
 %:
 	dh $@ --with python-virtualenv

--- a/pkg/requirements.txt
+++ b/pkg/requirements.txt
@@ -1,3 +1,3 @@
-sentry==8.9.0
+sentry==8.10.0
 sentry-slack==0.5.0
 psycopg2

--- a/pkg/setup.py
+++ b/pkg/setup.py
@@ -7,7 +7,7 @@ if __name__ == '__main__' and sys.argv[1] == 'test':
 
 setup(
     name='sentry',
-    version='8.9.0',
+    version='8.10.0',
     author='Raphaël Berbain',
     author_email='rberbain@dhatim.com',
     packages=[],


### PR DESCRIPTION
The build fails because this version of Sentry relies on a newer version of libsourcemap. We have to include https://github.com/getsentry/libsourcemap in the build process. This requires Rust.